### PR TITLE
Make tab title shorter

### DIFF
--- a/src/CborTextDocumentContentProvider.ts
+++ b/src/CborTextDocumentContentProvider.ts
@@ -5,7 +5,7 @@ export class CborTextDocumentContentProvider
   implements vscode.TextDocumentContentProvider
 {
   async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
-    const [_, cbor] = uri.toString().split(":");
+    const [_scheme, cbor, _tabTitle] = uri.toString().split(/[:\/]/);
 
     const size = cbor.length / 2;
     const diganostic = await diagnose(cbor);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,8 @@ export const activate = (context: vscode.ExtensionContext) => {
     vscode.commands.registerCommand(COMMAND_DIAGNOSE, async () => {
       let cbor = await getCbor();
       if (cbor && (await isValidCbor(cbor))) {
-        let uri = vscode.Uri.parse(`${SCHEME}:${cbor}`);
+        let tabTitle = cbor.slice(0, 20);
+        let uri = vscode.Uri.parse(`${SCHEME}:${cbor}/${tabTitle}`);
         let doc = await vscode.workspace.openTextDocument(uri);
         await vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,


### PR DESCRIPTION
Currently, VS Code displays the entire CBOR as the tab title, which makes working with tabs quite painful (especially when you want to open two or more CBOR diagnostic tabs at the same time). This PR shortens the title to the first 20 chars.

Before:
![Screenshot from 2022-04-15 14-02-39](https://user-images.githubusercontent.com/42035353/163568607-69373f73-32af-454a-a257-5ef08ff98642.png)

After:
![Screenshot from 2022-04-15 14-03-26](https://user-images.githubusercontent.com/42035353/163568601-05e06ac9-bd30-40ca-b178-af1f1dc6965f.png)
